### PR TITLE
Fix history page end date 500 error

### DIFF
--- a/app/Services/HistoryService.php
+++ b/app/Services/HistoryService.php
@@ -5,13 +5,19 @@ namespace App\Services;
 use Carbon\CarbonPeriod;
 
 class HistoryService {
+
+    const DATE_FORMAT = 'Y-m-d';
+
     public function buildForUser ($user) {
         $userGroups = $user->groups;
         $total = $userGroups->groupBy('pivot.recorded_at');
         $groupedEntries = $userGroups->pluck('pivot')->groupBy('recorded_at');
         $groupedEntriesKeys = $groupedEntries->keys();
+        $endDate = date(self::DATE_FORMAT);
 
-        $endDate = array_values(array_slice($groupedEntriesKeys->toArray(), -1))[0];
+        if(sizeof($groupedEntriesKeys) > 0) {
+            $endDate = array_values(array_slice($groupedEntriesKeys->toArray(), -1))[0];
+        }
 
         $filledEntries = $this->fillMissingDates($user->created_at, $endDate);
         $entries = collect($filledEntries)->merge($groupedEntries);
@@ -26,12 +32,12 @@ class HistoryService {
     }
 
     private function fillMissingDates ($startDate, $endDate) {
-        $startDate = $startDate->format('Y-m-d');
+        $startDate = $startDate->format(self::DATE_FORMAT);
         $period = new CarbonPeriod($startDate, $endDate);
         $dates = [];
 
         foreach ($period as $date) {
-            $dates[$date->format('Y-m-d')] = collect([[ 'checked' => 0 ]]);
+            $dates[$date->format(self::DATE_FORMAT)] = collect([[ 'checked' => 0 ]]);
         }
 
         return $dates;


### PR DESCRIPTION
https://trello.com/c/nsEs5BkE/223-500-server-error-on-history

### Problem

When a user views their calendar history without any previously "checked" food groups, a 500 error occurs because we're attempting to retrieve an end date from a food group that does not exist.

### Solution

- Sets a default end date (today's date) to prevent 500 error
- Use previous logic if food groups exist

### How to test

1. Create new user
2. Navigate to history page
3. [ ] Page should load without returning 500 error